### PR TITLE
Fix OSError if gtfs_path is URL

### DIFF
--- a/gtfs_functions/gtfs_functions.py
+++ b/gtfs_functions/gtfs_functions.py
@@ -294,8 +294,9 @@ class Feed:
         try:
             with ZipFile(self.gtfs_path) as myzip:
                 return myzip.namelist()    
+            
         # Try as a URL if the file is not in local
-        except FileNotFoundError as e:
+        except (FileNotFoundError, OSError) as e:
             
             r = requests.get(self.gtfs_path)
 

--- a/gtfs_functions/gtfs_functions.py
+++ b/gtfs_functions/gtfs_functions.py
@@ -1146,7 +1146,7 @@ def extract_file(file, feed):
                 return logging.info(f'File "{file}.txt" not found.')     
         
         # Try as a URL
-        except FileNotFoundError as e:
+        except (FileNotFoundError, OSError) as e:
             if f'{file}.txt' in files:
                 r = requests.get(gtfs_path)
                 with ZipFile(io.BytesIO(r.content)) as myzip:


### PR DESCRIPTION
Encountered the following problem with URL https://www.transportforireland.ie/transitData/Data/GTFS_All.zip which is now getting considered in the exception handling of the get_files function:

`OSError: [Errno 22] Invalid argument: 'https://www.transportforireland.ie/transitData/Data/GTFS_All.zip'`