### PR TITLE
Fix bug that causes some trips to be dropped from parsed schedules.

### DIFF
--- a/gtfs_functions/gtfs_functions.py
+++ b/gtfs_functions/gtfs_functions.py
@@ -1128,7 +1128,8 @@ def extract_file(file, feed):
         'shape_id': str,
         'stop_id': str,
         'route_id': str,
-        'trip_id': str
+        'trip_id': str,
+        'service_id': str
     }
 
     files = feed.files


### PR DESCRIPTION
The code that reads raw GTFS data into dataframes doesn't have an explicit data type for service_id, requiring it to be inferred. In schedules with a mix of numeric and alphanumeric service ids, this can cause some to be read as numbers and some as strings, preventing joins from working properly. This change makes service_id values be from CSV as strings.

The following snippet should illustrate the issue for at least the next few weeks:

```
feed = Feed("https://www.transitchicago.com/downloads/sch_data/google_transit.zip",
            time_windows=[0, 6, 10, 16, 19, 24],
            start_date='2024-05-26', end_date='2024-05-26')
print(feed.lines_freq)
```